### PR TITLE
fix: add 'he' to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
-    "flexsearch": "^0.6.32"
+    "flexsearch": "^0.6.32",
+    "he": "^1.2.0"
   },
   "description": "En/De/Cn/Ja/Ko languages full text search",
   "homepage": "https://github.com/QYueWang/vuepress-plugin-flexsearch-pro",


### PR DESCRIPTION
The `he` package is used in `utils.js`.
It is better to list `he` in `dependencies` of `package.json`.